### PR TITLE
fix HdOSPRayRendererPlugin::IsSupported for USD 23

### DIFF
--- a/hdOSPRay/rendererPlugin.cpp
+++ b/hdOSPRay/rendererPlugin.cpp
@@ -80,8 +80,17 @@ HdOSPRayRendererPlugin::DeleteRenderDelegate(HdRenderDelegate* renderDelegate)
     ospShutdown();
 }
 
+#if PXR_MINOR_VERSION >= 23
+bool
+HdOSPRayRendererPlugin::IsSupported(bool gpuEnabled) const
+{
+    return true;
+}
+#else
 bool
 HdOSPRayRendererPlugin::IsSupported() const
 {
     return true;
 }
+}
+#endif

--- a/hdOSPRay/rendererPlugin.h
+++ b/hdOSPRay/rendererPlugin.h
@@ -20,7 +20,11 @@ public:
     virtual void
     DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
+#if PXR_MINOR_VERSION >= 23
+    virtual bool IsSupported(bool gpuEnabled) const override;
+#else
     virtual bool IsSupported() const override;
+#endif
 
 private:
     HdOSPRayRendererPlugin(const HdOSPRayRendererPlugin&) = delete;


### PR DESCRIPTION
USD 23+ changed the interface of HdRendererPlugin for GPU.

https://github.com/PixarAnimationStudios/OpenUSD/commit/847a5c58cd5c44d75affbd480d16e551c5f7fca6

This PR fixes the compilation on latest USD 23+.