### PR TITLE
Fix PROJECT() defined before minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
+if (WIN32)
+    cmake_minimum_required(VERSION 3.1.1)
+else()
+    cmake_minimum_required(VERSION 2.8.8)
+endif()
 
 PROJECT(hdOSPRayPlugin)
 
@@ -7,11 +12,6 @@ set(HDOSPRAY_VERSION_MINOR 1)
 set(HDOSPRAY_VERSION_PATCH 0)
 set(HDOSPRAY_VERSION ${HDOSPRAY_VERSION_MAJOR}.${HDOSPRAY_VERSION_MINOR}.${HDOSPRAY_VERSION_PATCH})
 
-if (WIN32)
-    cmake_minimum_required(VERSION 3.1.1)
-else()
-    cmake_minimum_required(VERSION 2.8.8)
-endif()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     if (WIN32)


### PR DESCRIPTION
CMake said:
```
CMake Warning (dev) at CMakeLists.txt:3 (PROJECT):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```