### PR TITLE
Fix scaling of texture coordinates for previewsurface

### DIFF
--- a/hdOSPRay/material.cpp
+++ b/hdOSPRay/material.cpp
@@ -508,8 +508,6 @@ HdOSPRayMaterial::_ProcessTextureNode(HdMaterialNode node,
             filename = path.GetResolvedPath();
         } else if (name == HdOSPRayMaterialTokens->scale) {
             texture.scale = value.Get<GfVec4f>();
-            texture.xfm_scale = GfVec2f(texture.scale[0], texture.scale[1]);
-            texture.hasXfm = true;
         } else if (name == HdOSPRayMaterialTokens->wrapS) {
         } else if (name == HdOSPRayMaterialTokens->wrapT) {
         } else if (name == HdOSPRayMaterialTokens->st) {
@@ -693,8 +691,8 @@ HdOSPRayMaterial::UpdatePrincipledMaterial(const std::string& rendererType)
                                           vec2f(-value.xfm_translation[0],
                                                 -value.xfm_translation[1]));
                     _ospMaterial.setParam(st_scale.c_str(),
-                                          vec2f(value.xfm_scale[0],
-                                                value.xfm_scale[1]));
+                                          vec2f(1.0f / value.xfm_scale[0],
+                                                1.0f / value.xfm_scale[1]));
                     _ospMaterial.setParam(st_rotation.c_str(),
                                           -value.xfm_rotation);
                 }
@@ -771,8 +769,8 @@ HdOSPRayMaterial::UpdateCarPaintMaterial()
                                       vec2f(-value.xfm_translation[0],
                                             -value.xfm_translation[1]));
                 _ospMaterial.setParam(st_scale.c_str(),
-                                      vec2f(value.xfm_scale[0],
-                                            value.xfm_scale[1]));
+                                      vec2f(1.0f / value.xfm_scale[0],
+                                            1.0f / value.xfm_scale[1]));
                 _ospMaterial.setParam(st_rotation.c_str(), -value.xfm_rotation);
             }
         }
@@ -826,8 +824,8 @@ HdOSPRayMaterial::UpdateLuminousMaterial()
                                       vec2f(-value.xfm_translation[0],
                                             -value.xfm_translation[1]));
                 _ospMaterial.setParam(st_scale.c_str(),
-                                      vec2f(value.xfm_scale[0],
-                                            value.xfm_scale[1]));
+                                      vec2f(1.0f / value.xfm_scale[0],
+                                            1.0f / value.xfm_scale[1]));
                 _ospMaterial.setParam(st_rotation.c_str(), -value.xfm_rotation);
             }
         }
@@ -865,8 +863,8 @@ HdOSPRayMaterial::UpdateGlassMaterial()
                                       vec2f(-value.xfm_translation[0],
                                             -value.xfm_translation[1]));
                 _ospMaterial.setParam(st_scale.c_str(),
-                                      vec2f(value.xfm_scale[0],
-                                            value.xfm_scale[1]));
+                                      vec2f(1.0f / value.xfm_scale[0],
+                                            1.0f / value.xfm_scale[1]));
                 _ospMaterial.setParam(st_rotation.c_str(), -value.xfm_rotation);
             }
         }
@@ -902,8 +900,8 @@ HdOSPRayMaterial::UpdateThinGlassMaterial()
                                       vec2f(-value.xfm_translation[0],
                                             -value.xfm_translation[1]));
                 _ospMaterial.setParam(st_scale.c_str(),
-                                      vec2f(value.xfm_scale[0],
-                                            value.xfm_scale[1]));
+                                      vec2f(1.0f / value.xfm_scale[0],
+                                            1.0f / value.xfm_scale[1]));
                 _ospMaterial.setParam(st_rotation.c_str(), -value.xfm_rotation);
             }
         }


### PR DESCRIPTION
### Description of Change(s)
The issue was introduced with commit ba61426ade3383119aa3cffa2c0ed21d40ebfa58. Correct scaling requires that ospray texture map scale is set to the reciprocal of scale factor from Transform2dNode. Also it seems not to be correct to take scale factor from UsdUVTexture as scale factor for texture map. Instead the scale factor from UsdUVTexture is meant to be applied to the values which are read from the texture, but this is not part of this commit.