### PR TITLE
fix mesh with material and displayColor

### DIFF
--- a/hdOSPRay/mesh.cpp
+++ b/hdOSPRay/mesh.cpp
@@ -262,8 +262,6 @@ HdOSPRayMesh::_PopulateOSPMesh(HdSceneDelegate* sceneDelegate,
     const HdRenderIndex& renderIndex = sceneDelegate->GetRenderIndex();
     bool useQuads = _UseQuadIndices(renderIndex, _topology);
 
-    const HdOSPRayMaterial* material = _GetAssignedMaterial(renderIndex);
-
     if (HdChangeTracker::IsSubdivTagsDirty(*dirtyBits, id)
         && _topology.GetRefineLevel() > 0) {
         _topology.SetSubdivTags(sceneDelegate->GetSubdivTags(id));
@@ -317,6 +315,8 @@ HdOSPRayMesh::_PopulateOSPMesh(HdSceneDelegate* sceneDelegate,
         || HdChangeTracker::IsPrimvarDirty(*dirtyBits, id,
                                            HdOSPRayTokens->st)) {
         newMesh = true;
+
+        const HdOSPRayMaterial* material = _GetAssignedMaterial(renderIndex);
 
         if (!_refined) {
             if (useQuads) {

--- a/hdOSPRay/mesh.h
+++ b/hdOSPRay/mesh.h
@@ -26,6 +26,7 @@ namespace opp = ospray::cpp;
 PXR_NAMESPACE_USING_DIRECTIVE
 
 class HdStDrawItem;
+class HdOSPRayMaterial;
 class HdOSPRayRenderParam;
 
 /// \class HdOSPRayMesh
@@ -87,6 +88,8 @@ private:
                                     const VtVec3fArray& normals,
                                     const VtVec3fArray& colors, bool refined,
                                     bool useQuads);
+
+    const HdOSPRayMaterial* _GetAssignedMaterial(const HdRenderIndex& renderIndex) const;
 
     ///  \param meshUtil
     ///  \param useQuads


### PR DESCRIPTION
Vertex color (displayColor) is ignored if the mesh has a material. In our understanding the displayColor is meant to be used in the absence of any specified shader or if a material connects to it via UsdPrimvarReader.