### PR TITLE
Fix initialization of shadow catcher plane

### DIFF
--- a/hdOSPRay/config.h
+++ b/hdOSPRay/config.h
@@ -140,7 +140,7 @@ public:
     bool ambientLight { false };
 
     ///  ShadowCatcher for ospray path tracer
-    GfVec4f shadowCatcherPlane;
+    GfVec4f shadowCatcherPlane { 0, 0, 0, 0 };
 
     ///  Geometry Lights
     bool geometryLights { false };

--- a/hdOSPRay/renderPass.h
+++ b/hdOSPRay/renderPass.h
@@ -240,7 +240,7 @@ private:
     int _russianRouletteStartDepth { HDOSPRAY_DEFAULT_RR_START_DEPTH };
     float _minContribution { HDOSPRAY_DEFAULT_MIN_CONTRIBUTION };
     float _maxContribution { HDOSPRAY_DEFAULT_MAX_CONTRIBUTION };
-    GfVec4f _shadowCatcherPlane;
+    GfVec4f _shadowCatcherPlane { 0, 0, 0, 0 };
     bool _geometryLights {false};
 
     float _aoRadius { HDOSPRAY_DEFAULT_AO_RADIUS };


### PR DESCRIPTION
### Description of Change(s)
There could be a random shadow catcher because plane was not initialized. GfVec4f() does not initialize values.